### PR TITLE
Draw ball before frame increments & change paddle collision

### DIFF
--- a/game.js
+++ b/game.js
@@ -52,12 +52,11 @@ function draw(){
         text("s c o r e    :    " + score,1000,140);
 
 
+        arc(initX,initY,20,20,0,360);
         initX+= x_increment;
         initY+= y_increment;
-        arc(initX,initY,20,20,0,360);
 
-        
-        if(Math.abs(initX-60)<=10 &&(initY >= (mouseY-70) && initY <=(mouseY+70))){
+        if(initX <= 70 &&(initY >= (mouseY-70) && initY <=(mouseY+70))){
             hits+=1;
             aud2.play();
             x_increment = hits;


### PR DESCRIPTION
The current implementation seems fine -- I tried playing at really high speeds, and it keeps up pretty well!

Drawing the ball before the frame increments & calculations will give the ball a frame to calculate for collision, which hopefully makes it look like it's hitting the paddle more consistently.

I also changed the collision box for the paddle to extend all the way to the left -- the paddle seems to keep up better at higher speeds w/ this change and can hit the ball on the edges now.